### PR TITLE
Sort mana colors by original order

### DIFF
--- a/app/src/main/res/layout/fragment_mtgmana_calculator.xml
+++ b/app/src/main/res/layout/fragment_mtgmana_calculator.xml
@@ -39,7 +39,19 @@
             android:paddingTop="@dimen/padding_normal">
 
             <include
+                android:id="@+id/mana_input_white"
+                layout="@layout/mana_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
                 android:id="@+id/mana_input_blue"
+                layout="@layout/mana_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
+                android:id="@+id/mana_input_black"
                 layout="@layout/mana_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
@@ -52,18 +64,6 @@
 
             <include
                 android:id="@+id/mana_input_green"
-                layout="@layout/mana_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <include
-                android:id="@+id/mana_input_black"
-                layout="@layout/mana_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <include
-                android:id="@+id/mana_input_white"
                 layout="@layout/mana_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />


### PR DESCRIPTION
This minor UI fix is meant to sort the color sliders in the original _WUBRG_ order.